### PR TITLE
Refactor: Use Signal to pass account opening status back to parent

### DIFF
--- a/src/common/account_context.py
+++ b/src/common/account_context.py
@@ -2,3 +2,7 @@ from pydantic import BaseModel
 
 class ClientContext(BaseModel):
     client_id: str | None = None
+
+class UpdateAccountOpeningStateInput(BaseModel):
+    account_name: str
+    state: str

--- a/src/common/agent_constants.py
+++ b/src/common/agent_constants.py
@@ -48,26 +48,24 @@ OPEN_ACCOUNT_HANDOFF = "A helpful agent that can open a new investment account."
 OPEN_ACCOUNT_INSTRUCTIONS = f""""{RECOMMENDED_PROMPT_PREFIX}
         You are a helpful agent. You can use your tools to open a new investment account and check 
         the status of a newly opened investment account. If you are talking to a customer, you were 
-        likely transferred from the {INVEST_AGENT_NAME}. 
+        likely transferred from the {INVEST_AGENT_NAME}.
         You are responsible for handling the opening a new investment account. This is the only operation
         that you can do -- open a new investment account. For all other requests, transfer back to
-        the {INVEST_AGENT_NAME} 
+        the {INVEST_AGENT_NAME}
         # Routine
         1. If you don't have a client ID, ask for one
         2. Use the open_new_investment_account tool to begin the process. 
            If the tool requires additional information, ask the user for the required data. Remember
            to save the return value as this will be required in the other tools. 
-        3. Next, use the get_current_client_info tool to retrieve their current data. 
+        3. Next, check the conversation history to see if the account is waiting for KYC approval.
+           Use the get_current_client_info tool to retrieve their current data.
            Display this to the user and ask if this information is correct and up to date. 
            If it is, call the approve_kyc tool
            If it isn't, ask the user to update their information. This needs to be at least one 
            field that needs to be changed. Once updated, call the update_client_details tool
-        4. Ask the user if they would like for you to check the state of this process. If so,  
-           use the open_account_current_state tool to retrieve the state of the account opening process. 
-           Show the user the value returned from this tool. 
-           When this returns "Complete", the process account has been opened. Tell the user their 
-           account is opened. 
-           Continue to ask the user if they would like for you to check the state of this process
-           until it is complete.
-        5. Once the account opening process is complete, hand off to the {INVEST_AGENT_NAME}. 
+        4. Check the conversation history to see if the account is waiting for compliance review
+           If it is, ask the user to wait for compliance review to be completed.
+        5. Check the conversation history to see if the account creation is completed
+           Once the account opening process is fully complete, including KYC approval and compliance approval, hand off to the {INVEST_AGENT_NAME}.
+           Otherwise, ask the user to wait for the account to be opened.
         6. If the customer asks a question that is not related to the routine, hand off to the {INVEST_AGENT_NAME}."""

--- a/src/temporal_supervisor/activities/open_account.py
+++ b/src/temporal_supervisor/activities/open_account.py
@@ -65,11 +65,3 @@ class OpenAccount:
         result = await handle.execute_update(OpenInvestmentAccountWorkflow.update_client_details,
                                              args=[client_details_dict])
         return result
-
-    @staticmethod
-    @activity.defn
-    async def current_state(workflow_id: str) -> str:
-        # get the handle from the workflow id
-        handle = await OpenAccount.get_workflow_handle(workflow_id)
-        result = await handle.query(OpenInvestmentAccountWorkflow.get_current_state)
-        return result

--- a/src/temporal_supervisor/run_worker.py
+++ b/src/temporal_supervisor/run_worker.py
@@ -88,7 +88,6 @@ async def main():
             OpenAccount.get_current_client_info,
             OpenAccount.update_client_details,
             OpenAccount.approve_kyc,
-            OpenAccount.current_state
         ],
     )
     print(f"Running worker on {client_helper.address}")


### PR DESCRIPTION
Instead of polling from the parent, use Signal to update the parent workflow about the account opening status.